### PR TITLE
fix(msrv): set the msrv based on use, dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["IP", "CIDR", "network", "prefix", "subnet"]
 categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 edition = "2018"
-rust-version = "1.31"
+rust-version = "1.46"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 edition = "2018"
-rust-version = "1.46"
+rust-version = "1.61"
 
 [features]
 default = ["std"]

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1781,8 +1781,8 @@ mod tests {
     use super::*;
 
     macro_rules! make_ipnet_vec {
-        ($($x:expr),*) => ( vec![$($x.parse::<IpNet>().unwrap(),)*] );
-        ($($x:expr,)*) => ( make_ipnet_vec![$($x),*] );
+        ($($x:expr_2021),*) => ( vec![$($x.parse::<IpNet>().unwrap(),)*] );
+        ($($x:expr_2021,)*) => ( make_ipnet_vec![$($x),*] );
     }
 
     #[test]
@@ -1838,7 +1838,7 @@ mod tests {
     }
 
     macro_rules! make_ipv4_subnets_test {
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr),*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021),*) => (
             #[test]
             fn $name() {
                 let subnets = IpSubnets::from(Ipv4Subnets::new(
@@ -1850,13 +1850,13 @@ mod tests {
                 assert_eq!(subnets.collect::<Vec<IpNet>>(), results);
             }
         );
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr,)*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021,)*) => (
             make_ipv4_subnets_test!($name, $start, $end, $min_prefix_len, $($x),*);
         );
     }
 
     macro_rules! make_ipv6_subnets_test {
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr),*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021),*) => (
             #[test]
             fn $name() {
                 let subnets = IpSubnets::from(Ipv6Subnets::new(
@@ -1868,7 +1868,7 @@ mod tests {
                 assert_eq!(subnets.collect::<Vec<IpNet>>(), results);
             }
         );
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr,)*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021,)*) => (
             make_ipv6_subnets_test!($name, $start, $end, $min_prefix_len, $($x),*);
         );
     }


### PR DESCRIPTION
the pre-existing use of `core::num::leading_ones` and the `syn` crate require an MSRV beyond that which is currently set.

- fix(msrv): num::leading_{one,zero}s requires v1.46
- fix(msrv): implicit dependency syn requires 1.61
- chore(msrv): rust v1.61 allows 2021 edition
