### PR TITLE
fix(msrv): dependencies require v1.61, 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["IP", "CIDR", "network", "prefix", "subnet"]
 categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 edition = "2018"
-rust-version = "1.31"
+rust-version = "1.46"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 edition = "2018"
-rust-version = "1.46"
+rust-version = "1.61"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the [documentation] for the full details. And find it on [Crates.io].
 
 ## Release 2.0 requirements
 
-Release 2.0 requires Rust 1.31 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
+Release 2.0 requires Rust 1.46 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the [documentation] for the full details. And find it on [Crates.io].
 
 ## Release 2.0 requirements
 
-Release 2.0 requires Rust 1.46 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
+Release 2.0 requires Rust 1.61 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
 
 ## Examples
 

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1781,8 +1781,8 @@ mod tests {
     use super::*;
 
     macro_rules! make_ipnet_vec {
-        ($($x:expr),*) => ( vec![$($x.parse::<IpNet>().unwrap(),)*] );
-        ($($x:expr,)*) => ( make_ipnet_vec![$($x),*] );
+        ($($x:expr_2021),*) => ( vec![$($x.parse::<IpNet>().unwrap(),)*] );
+        ($($x:expr_2021,)*) => ( make_ipnet_vec![$($x),*] );
     }
 
     #[test]
@@ -1838,7 +1838,7 @@ mod tests {
     }
 
     macro_rules! make_ipv4_subnets_test {
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr),*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021),*) => (
             #[test]
             fn $name() {
                 let subnets = IpSubnets::from(Ipv4Subnets::new(
@@ -1850,13 +1850,13 @@ mod tests {
                 assert_eq!(subnets.collect::<Vec<IpNet>>(), results);
             }
         );
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr,)*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021,)*) => (
             make_ipv4_subnets_test!($name, $start, $end, $min_prefix_len, $($x),*);
         );
     }
 
     macro_rules! make_ipv6_subnets_test {
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr),*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021),*) => (
             #[test]
             fn $name() {
                 let subnets = IpSubnets::from(Ipv6Subnets::new(
@@ -1868,7 +1868,7 @@ mod tests {
                 assert_eq!(subnets.collect::<Vec<IpNet>>(), results);
             }
         );
-        ($name:ident, $start:expr, $end:expr, $min_prefix_len:expr, $($x:expr,)*) => (
+        ($name:ident, $start:expr_2021, $end:expr_2021, $min_prefix_len:expr_2021, $($x:expr_2021,)*) => (
             make_ipv6_subnets_test!($name, $start, $end, $min_prefix_len, $($x),*);
         );
     }


### PR DESCRIPTION
due to use of std::num functions and the `syn` dependency, we must advance the MSRV.

- fix(msrv): num::leading_{one,zero}s requires v1.46
- fix(msrv): implicit dependency syn requires 1.61
- chore(msrv): rust v1.61 allows 2021 edition
